### PR TITLE
Updateing update-triplestore to proper image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,29 @@
-FROM yyz1989/rdf4j
+FROM ubuntu:18.04
+
+### 2. Get Java, Python and all required system libraries (version control etc)
+ENV JAVA_HOME="/usr/lib/jvm/java-1.8-openjdk"
+#ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
+
+RUN apt-get update && apt-get install -y software-properties-common && apt-get upgrade -y \
+ && apt-get install -y software-properties-common \
+  build-essential git \
+  openjdk-8-jre openjdk-8-jdk
 
 VOLUME /data
 
 ENV WORKSPACE=/opt/VFB
 ENV SERVER=http://192.168.0.1:8080
+ENV RDF4J_VERSION=3.4.4
+ENV RDF4J_SDK_DIR=${WORKSPACE}/rdf4j
+ENV RDF4J_SDK=https://www.eclipse.org/downloads/download.php?file=/rdf4j/eclipse-rdf4j-${RDF4J_VERSION}-sdk.zip\&r=1
 
 ENV BUILD_OUTPUT=${WORKSPACE}/build.out
 
+RUN apt-get -qq update && apt-get -qq -y install curl wget zip unzip
+RUN mkdir ${WORKSPACE}
+RUN wget ${RDF4J_SDK} -O ${WORKSPACE}/rdf4j-sdk.zip && unzip -d ${WORKSPACE}/rdf4j-sdk ${WORKSPACE}/rdf4j-sdk.zip
+RUN ls -l ${WORKSPACE} && mv ${WORKSPACE}/rdf4j-sdk/eclipse-rdf4j-${RDF4J_VERSION} ${RDF4J_SDK_DIR}
+RUN ls -l ${RDF4J_SDK_DIR}
 COPY process.sh /opt/VFB/process.sh
 COPY rdf4j_vfb.txt /opt/VFB/rdf4j_vfb.txt
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+
+# Building docker image
+VERSION = "v0.0.7" 
+IM=matentzn/vfb-pipeline-updatetriplestore
+PW=neo4j/neo
+OUTDIR=/Users/matentzn/tmp_data/vfb
+KB=http://kb.p2.virtualflybrain.org
+TS=http://host.docker.internal:8080
+
+docker-build:
+	@docker build --no-cache -t $(IM):$(VERSION) . \
+	&& docker tag $(IM):$(VERSION) $(IM):latest
+	
+docker-build-use-cache:
+	@docker build -t $(IM):$(VERSION) . \
+	&& docker tag $(IM):$(VERSION) $(IM):latest
+
+docker-run:
+	docker run --volume $(OUTDIR):/data -e SERVER=$(TS) $(IM)
+
+docker-clean:
+	docker kill $(IM) || echo not running ;
+	docker rm $(IM) || echo not made 
+
+docker-publish-no-build:
+	@docker push $(IM):$(VERSION) \
+	&& docker push $(IM):latest
+	
+docker-publish: docker-build-use-cache
+	@docker push $(IM):$(VERSION) \
+	&& docker push $(IM):latest
+
+QUERY=PREFIX%20rdfs%3A%20%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F01%2Frdf-schema%23%3E%0APREFIX%20owl%3A%20%3Chttp%3A%2F%2Fwww.w3.org%2F2002%2F07%2Fowl%23%3E%0APREFIX%20n2o%3A%20%3Chttp%3A%2F%2Fn2o.neo%2Fproperty%2F%3E%0APREFIX%20n2oc%3A%20%3Chttp%3A%2F%2Fn2o.neo%2Fcustom%2F%3E%0APREFIX%20dct%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Fterms%2F%3E%0A%0ACONSTRUCT%20%7B%0A%20%20%3Fdataset%20%3Fdsrel%20%3Fdsval%20.%20%0A%09%3Fimage%20%3Fimgrel%20%3Fimgval%20.%0A%09%3Fchannel%20%3Fchannelrel%20%3Fchannelval%20.%0A%7D%0A%0A%09WHERE%20%7B%0A%09%0A%09%3Fdataset%20n2o%3AnodeLabel%20%3Fnodelabel%20.%20%23%20This%20selects%20all%20datasets%0A%09%0A%09OPTIONAL%20%7B%0A%20%20%09%3Fdataset%20n2oc%3Aproduction%20%3Fproduction%20.%0A%09%09%23%20n2oc%3Aproduction%20is%20a%20bit%20brittle%20because%20IRI%20might%20be%20changed%20%28risk%21%29%0A%09%7D%0A%09%0A%09%3Fdataset%20%3Fdsrel%20%3Fdsval%20.%0A%20%20%0A%20%20OPTIONAL%20%7B%0A%20%20%09%20%3Fimage%20dct%3Asource%20%3Fdataset%20.%20%23in%20case%20a%20dataset%20does%20not%20have%20images%20yet%20this%20is%20an%20optional%20clause%0A%09%09%20%3Fimage%20%3Fimgrel%20%3Fimgval%20.%0A%09%7D%0A%20%20%0A%20%20OPTIONAL%20%7B%0A%20%20%09%3Fchannel%20%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2Fdepicts%3E%20%3Fimage%20.%20%23%20There%20does%20not%20always%20seem%20to%20be%20a%20channel%0A%09%09%3Fchannel%20%3Fchannelrel%20%3Fchannelval%20.%0A%20%20%7D%0A%09%0A%20%20FILTER%28%3Fproduction%3Dfalse%20%7C%7C%20%21bound%28%3Fproduction%29%29%20.%0A%20%20FILTER%28%3Fnodelabel%3D%22DataSet%22%29%20%0A%7D
+
+TSQ=http://ts.p2.virtualflybrain.org/rdf4j-server/repositories/vfb?query=$(QUERY)
+
+test_query:
+	wget $TSQ -O embargo.ttl

--- a/process.sh
+++ b/process.sh
@@ -8,7 +8,6 @@ echo "VFBTIME:"
 date
 
 VFBSETUP=${WORKSPACE}/rdf4j_vfb.txt
-RDF4J=/opt/eclipse-rdf4j-${RDF4J_VERSION}
 RDF4JSERVER=${SERVER}/rdf4j-server
 DATA=/data
 
@@ -23,7 +22,7 @@ done
 
 echo "connect "${RDF4JSERVER}|cat - ${VFBSETUP} > /tmp/out && mv /tmp/out ${VFBSETUP}
 cat ${VFBSETUP}
-cat ${VFBSETUP} | sh ${RDF4J}/bin/console.sh
+cat ${VFBSETUP} | sh ${RDF4J_SDK_DIR}/bin/console.sh
 
 ls -lh $DATA
 


### PR DESCRIPTION
- relieves the dependecy on the obsolete yyz1989/rdf4j image
- cleans up the installation of the RDF4J SK
- Add a Makefile that helps with local testing